### PR TITLE
Fixes: 'SvelteKit 2: New requirement: "Dynamic environment variables …

### DIFF
--- a/src/routes/airtable/+page.server.js
+++ b/src/routes/airtable/+page.server.js
@@ -1,7 +1,8 @@
 import Airtable from 'airtable';
-import { env } from '$env/dynamic/private';
+import { VITE_AIRTABLE_BASE_ID } from '$env/static/private';
+import { AIRTABLE_KEY } from '$env/static/private';
 
-const myBaseId = import.meta.env.VITE_AIRTABLE_BASE_ID;
+const myBaseId = VITE_AIRTABLE_BASE_ID;
 
 const myBaseConfig = {
     tableName: 'Organizations',
@@ -22,7 +23,7 @@ const myBaseConfig = {
 function setupBase(baseId) {
     Airtable.configure({
         endpointUrl: 'https://api.airtable.com',
-        apiKey: env.AIRTABLE_KEY
+        apiKey: AIRTABLE_KEY
     });
     var base = Airtable.base(baseId);
 


### PR DESCRIPTION
…cannot be used during prerendering" causes build time errors'

- https://github.com/baisong/sveltekit-airtable-quickstart/issues/1

- Converting `env` imports from `dynamic` to `static`, as per the new SvelteKit 2 requirement:
    + https://kit.svelte.dev/docs/migrating-to-sveltekit-2#dynamic-environment-variables-cannot-be-used-during-prerendering

- Converting to explicitly imported `env` variables:
    + https://github.com/sveltejs/kit/issues/11378#issuecomment-1861074759
    + https://kit.svelte.dev/docs/modules#$env-static-private